### PR TITLE
Wildcards should only be referenced by default when used with the lay…

### DIFF
--- a/controllers/resources_controller.py
+++ b/controllers/resources_controller.py
@@ -511,11 +511,7 @@ class ResourcesController(Controller):
         # layers(and attributes) that the ConfigGenerator sees.
 
         for res in resources:
-            # Wildcards are always marked as referenced
-            if "*" in res.name:
-                res.not_referenced = False
-                continue
-            elif res.type == "map":
+            if res.type == "map":
                 if res.name not in maps_from_config:
                     res.not_referenced = True
 
@@ -530,7 +526,10 @@ class ResourcesController(Controller):
                     for resource in resources_from_config:
                         # data and layer types are handled the same
                         # Check whether the resource parent is referenced
-                        if (res.type == "data" or res.type == "layer") and \
+                        if "*" in res.name and res.parent.name in maps_from_config:
+                            res.not_referenced = False
+                            continue
+                        elif (res.type == "data" or res.type == "layer") and \
                             res.parent.name in maps_from_config and \
                                 resource["map"] == res.parent.name:
 


### PR DESCRIPTION
…er/data type and also check wether the parent exists for the wildcard