### PR TITLE
Ensure groups exist in themes when adding a new theme group

### DIFF
--- a/plugins/themes/controllers/themes_controller.py
+++ b/plugins/themes/controllers/themes_controller.py
@@ -302,6 +302,7 @@ class ThemesController:
         return redirect(url_for("themes"))
 
     def add_theme_group(self):
+        self.themesconfig["themes"]["groups"] = self.themesconfig["themes"].get("groups", [])
         self.themesconfig["themes"]["groups"].append({
             "title": "new theme group",
             "items": []


### PR DESCRIPTION
Hi,

When I don't have any groups in my theme configuration, there is an error raised if I want to add a new first group in Themes plugin because `groups` is not a key of `themesconfig["themes"]`.

Thanks