### PR TITLE
Load themes configuration each time background layers are listed

### DIFF
--- a/plugins/themes/controllers/backgroundlayers_controller.py
+++ b/plugins/themes/controllers/backgroundlayers_controller.py
@@ -43,6 +43,7 @@ class BackgroundLayersController():
 
     def index(self):
         """Show backgroundlayers."""
+        self.themesconfig = ThemeUtils.load_themesconfig(self.app, self.handler)
         layers = []
         for layer in self.themesconfig["themes"]["backgroundLayers"]:
             layers.append(layer)


### PR DESCRIPTION
Fix #40 

As in themes controller, we need to load again configuration when background layers are listed in `index` function.