### PR TITLE
Add wmts style format requestencoding

### DIFF
--- a/plugins/themes/controllers/backgroundlayers_controller.py
+++ b/plugins/themes/controllers/backgroundlayers_controller.py
@@ -111,6 +111,9 @@ class BackgroundLayersController():
                 backgroundlayer["tileMatrixPrefix"] = ""
                 backgroundlayer["tileMatrixSet"] = form.tileMatrixSet.data
                 backgroundlayer["projection"] = form.projection.data
+                backgroundlayer["format"] = form.format.data                
+                backgroundlayer["requestEncoding"] = "KVP"
+                backgroundlayer["style"] = form.style.data  
                 backgroundlayer["originX"] = float(form.originX.data)
                 backgroundlayer["originY"] = float(form.originY.data)
                 resolutions = [

--- a/plugins/themes/controllers/backgroundlayers_controller.py
+++ b/plugins/themes/controllers/backgroundlayers_controller.py
@@ -112,7 +112,7 @@ class BackgroundLayersController():
                 backgroundlayer["tileMatrixSet"] = form.tileMatrixSet.data
                 backgroundlayer["projection"] = form.projection.data
                 backgroundlayer["format"] = form.format.data                
-                backgroundlayer["requestEncoding"] = "KVP"
+                backgroundlayer["requestEncoding"] = form.requestEncoding.data
                 backgroundlayer["style"] = form.style.data  
                 backgroundlayer["originX"] = float(form.originX.data)
                 backgroundlayer["originY"] = float(form.originY.data)

--- a/plugins/themes/forms/backgroundlayer_form.py
+++ b/plugins/themes/forms/backgroundlayer_form.py
@@ -25,6 +25,7 @@ class WMTSLayerForm(FlaskForm):
     url = HiddenField(validators=[DataRequired(), URL()])
     name = HiddenField(validators=[DataRequired()])
     style = HiddenField(validators=[DataRequired()])
+    format = HiddenField(validators=[DataRequired()])
     title = StringField("Title")
     # tileMatrixPrefix = StringField("TileMatrixPrefix")
     tileMatrixSet = HiddenField(validators=[DataRequired()])

--- a/plugins/themes/forms/backgroundlayer_form.py
+++ b/plugins/themes/forms/backgroundlayer_form.py
@@ -35,6 +35,7 @@ class WMTSLayerForm(FlaskForm):
     resolutions = HiddenField(validators=[DataRequired()])
     tileSize = HiddenField(validators=[DataRequired()])
     capabilities = HiddenField(validators=[DataRequired()])
+    requestEncoding = HiddenField(validators=[DataRequired()])
     with_capabilities = BooleanField("Save capabilities? \
         (Only needed for QGIS Server WMTS!)"
     )

--- a/plugins/themes/templates/wmtslayer.html
+++ b/plugins/themes/templates/wmtslayer.html
@@ -22,6 +22,7 @@
       $('#name').val($(this).find('td.wmts-name').text());
       $('#tileMatrixSet').val($(this).find('td.wmts-tilematrix').text());
       $('#style').val($(this).find('td.wmts-style').text());
+      $('#format').val($(this).find('td.wmts-format').text());
       $('#projection').val($(this).find('td.wmts-crs').text());
       $('#originX').val($(this).find('td.wmts-originX').text());
       $('#originY').val($(this).find('td.wmts-originY').text());
@@ -135,6 +136,7 @@
       {{ form.url }}
       {{ form.name }}
       {{ form.style }}
+      {{ form.format }}
       {{ form.tileMatrixSet }}
       {{ form.projection }}
       {{ form.originX }}

--- a/plugins/themes/templates/wmtslayer.html
+++ b/plugins/themes/templates/wmtslayer.html
@@ -8,6 +8,7 @@
   <script type="text/javascript">
     // TODO: add more proj4 defs
     proj4.defs("EPSG:25832","+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs");
+    proj4.defs("EPSG:3948","+proj=lcc +lat_1=47.25 +lat_2=48.75 +lat_0=48 +lon_0=3 +x_0=1700000 +y_0=7200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs ");
     ol.proj.proj4.register(proj4);
 
     // highlight selected row and set hidden vars

--- a/plugins/themes/templates/wmtslayer.html
+++ b/plugins/themes/templates/wmtslayer.html
@@ -9,6 +9,7 @@
     // TODO: add more proj4 defs
     proj4.defs("EPSG:25832","+proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs");
     proj4.defs("EPSG:3948","+proj=lcc +lat_1=47.25 +lat_2=48.75 +lat_0=48 +lon_0=3 +x_0=1700000 +y_0=7200000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs ");
+    proj4.defs("EPSG:2154","+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs");
     ol.proj.proj4.register(proj4);
 
     // highlight selected row and set hidden vars

--- a/plugins/themes/templates/wmtslayer.html
+++ b/plugins/themes/templates/wmtslayer.html
@@ -28,6 +28,7 @@
       $('#originY').val($(this).find('td.wmts-originY').text());
       $('#tileSize').val($(this).find('td.wmts-tilesize').text());
       $('#resolutions').val($(this).find('td.wmts-resolutions').text());
+      $('#requestEncoding').val($(this).find('td.wmts-requestEncoding').text());
     });
 
     // read capabilities from input-url
@@ -74,6 +75,7 @@
             row += '<td class="wmts-originY hidden">' + options.tileGrid.origins_[0][1] + '</td>';
             row += '<td class="wmts-tilesize hidden">' + [options.tileGrid.tileSizes_[0], options.tileGrid.tileSizes_[0]] + '</td>';
             row += '<td class="wmts-resolutions hidden">' + options.tileGrid.resolutions_ + '</td>';
+            row += '<td class="wmts-requestEncoding hidden">' + options.requestEncoding + '</td>';
             row += '</tr>';
             $('#wmts-table > tbody:last-child').append(row);
           });
@@ -142,6 +144,7 @@
       {{ form.originX }}
       {{ form.originY }}
       {{ form.resolutions }}
+      {{ form.requestEncoding }}
       {{ form.tileSize }}
       {{ wtf.form_field(form.submit, class="btn btn-primary") }}
     </form>


### PR DESCRIPTION
Hello,

To be able to add some french WMTS in admin part (with theme plugin), we need to get style, format and request encoding defined in Get Capabilities. 
For example : https://wxs.ign.fr/decouverte/geoportail/wmts?SERVICE=WMTS&REQUEST=GetCapabilities

We also add 3948 and 2154 EPSG configuration for our use. I let them if it could be useful for other people.

Have a good day !

Gwendoline  
