### PR TITLE
Add option to activate tooltip by default in the theme plugin

### DIFF
--- a/plugins/themes/controllers/themes_controller.py
+++ b/plugins/themes/controllers/themes_controller.py
@@ -407,6 +407,8 @@ class ThemesController:
                 form.default.data = theme["default"]
             if "tiled" in theme:
                 form.tiled.data = theme["tiled"]
+            if "mapTips" in theme:
+                form.mapTips.data = theme["mapTips"]
             if "thumbnail" in theme:
                 form.thumbnail.data = theme["thumbnail"]
             if "attribution" in theme:
@@ -490,6 +492,10 @@ class ThemesController:
         item["tiled"] = False
         if form.tiled.data:
             item["tiled"] = True
+        
+        item["mapTips"] = False
+        if form.mapTips.data:
+            item["mapTips"] = True
 
         if form.thumbnail.data:
             item["thumbnail"] = form.thumbnail.data

--- a/plugins/themes/forms/theme_form.py
+++ b/plugins/themes/forms/theme_form.py
@@ -100,7 +100,6 @@ class ThemeForm(FlaskForm):
      mapTips = BooleanField(
         "Enable tooltip by default",
         description="Enable the theme tooltip by default",
-        default = True,
         validators=[Optional()]
     )
     skipEmptyFeatureAttributes = BooleanField(

--- a/plugins/themes/forms/theme_form.py
+++ b/plugins/themes/forms/theme_form.py
@@ -97,6 +97,12 @@ class ThemeForm(FlaskForm):
         description="Tiling the layers",
         validators=[Optional()]
     )
+     mapTips = BooleanField(
+        "Enable tooltip by default",
+        description="Enable the theme tooltip by default",
+        default = True,
+        validators=[Optional()]
+    )
     skipEmptyFeatureAttributes = BooleanField(
         "Skip empty feature attributes",
         description="Optional, whether to skip empty attributes in the identify results. Default is false.",

--- a/plugins/themes/templates/theme.html
+++ b/plugins/themes/templates/theme.html
@@ -69,6 +69,7 @@
     {{ wtf.form_field(form.collapseLayerGroupsBelowLevel, form_type="horizontal", horizontal_columns=('sm', 2, 5)) }}
     {{ wtf.form_field(form.default, form_type="horizontal", horizontal_columns=('sm', 2, 5)) }}
     {{ wtf.form_field(form.tiled, form_type="horizontal", horizontal_columns=('sm', 2, 5)) }}
+    {{ wtf.form_field(form.mapTips, form_type="horizontal", horizontal_columns=('sm', 2, 5)) }}
     {{ wtf.form_field(form.skipEmptyFeatureAttributes, form_type="horizontal", horizontal_columns=('sm', 2, 5)) }}
     <div data-toggle="fieldset" class="form-group">
       <div class="col-sm-7">


### PR DESCRIPTION
This PR add the option to enable the tooltip by default in the themes plugin.
I set it to true by default because I think most of the themes have tooltip, and if there's none, nothing happen so no lose. 
Do not hesitate to notice me if anything's wrong.

Regards, Clément. 