### PR TITLE
Themes plugin: get default search providers to fill field in theme form

### DIFF
--- a/plugins/themes/controllers/themes_controller.py
+++ b/plugins/themes/controllers/themes_controller.py
@@ -377,12 +377,14 @@ class ThemesController:
             form = ThemeForm(url=theme["url"])
 
         crslist = ThemeUtils.get_crs(self.app, self.handler)
+        defaultSearchProvidersList = ThemeUtils.get_default_search_providers(self.app, self.handler)
 
         form.url.choices = [("", "---")] + ThemeUtils.get_projects(self.app, self.handler)
         form.thumbnail.choices = ThemeUtils.get_mapthumbs(self.app, self.handler)
         form.format.choices = ThemeUtils.get_format()
         form.mapCrs.choices = crslist
         form.additionalMouseCrs.choices = crslist
+        form.searchProviders.choices = defaultSearchProvidersList
         form.backgroundLayersList = self.get_backgroundlayers()
 
         if form.backgroundLayers.data:
@@ -423,13 +425,7 @@ class ThemesController:
             if "additionalMouseCrs" in theme:
                 form.additionalMouseCrs.data = theme["additionalMouseCrs"]
             if "searchProviders" in theme:
-                searchProviders = []
-                for provider in theme["searchProviders"]:
-                    if "key" in provider:
-                        searchProviders.append(provider["key"])
-                    else:
-                        searchProviders.append(provider)
-                form.searchProviders.data = ",".join(searchProviders)
+                form.searchProviders.data = theme["searchProviders"]
             if "scales" in theme:
                 form.scales.data = ", ".join(map(str, theme["scales"]))
             if "printScales" in theme:
@@ -524,8 +520,9 @@ class ThemesController:
 
         item["searchProviders"] = []
         if form.searchProviders.data:
-            for provider in form.searchProviders.data.split(","):
-                item["searchProviders"].append(provider)
+            item["searchProviders"] = form.searchProviders.data
+        else:
+            if "searchProviders" in item: del item["searchProviders"]
 
         if form.scales.data:
             item["scales"] = list(map(int, form.scales.data.replace(

--- a/plugins/themes/forms/theme_form.py
+++ b/plugins/themes/forms/theme_form.py
@@ -48,12 +48,11 @@ class ThemeForm(FlaskForm):
         description=("Additional CRS for the mouse coordinate display."),
         validators=[Optional()]
     )
-    searchProviders = StringField(
+    searchProviders = SelectMultipleField(
         "Search providers",
         description="List of available search providers.",
-        default=("coordinates"),
-        validators=[Regexp(r'^(\w+)(,\s*\w+)*$',
-                    message="Please enter a comma separted list of names.")]
+        validators=[Optional()],
+        default=("coordinates")
     )
     scales = StringField(
         "Scales",

--- a/plugins/themes/utils/themes.py
+++ b/plugins/themes/utils/themes.py
@@ -136,3 +136,23 @@ class ThemeUtils():
         return (["EPSG:3857", "EPSG:3857"],
                 ["EPSG:4647", "EPSG:4647"],
                 ["EPSG:25832", "EPSG:25832"])
+
+    @staticmethod
+    def get_default_search_providers(app, handler):
+        """Return default search providers"""
+        current_handler = handler()
+        config_in_path = current_handler.config().get("input_config_path")
+        tenantConfig = os.path.join(config_in_path, current_handler.tenant, 'tenantConfig.json')
+
+        try:
+            with open(tenantConfig, encoding="utf-8") as fh:
+                config = json.load(fh)
+                if "themesConfig" in config:
+                    themes_config = config["themesConfig"]
+                    if "defaultSearchProviders" in themes_config:
+                        return themes_config["defaultSearchProviders"]
+        except IOError as e:
+            app.logger.error("Error reading tenantConfig.json: {}".format(
+                e.strerror))
+
+        return (["coordinates"])


### PR DESCRIPTION
Hi,

This PR aims to propose a list of default search providers when adding/updating a theme with `themes` plugin. Administrator user could not know what are the search providers that have been configured in the app so this could help. There must be `defaultSearchProviders` defined to be able to retrieve them.

@manisandro do you know a way to get all Search Providers defined in https://github.com/qgis/qwc2-demo-app/blob/master/js/SearchProviders.js#L407 in admin-gui service ?

Thanks