### PR TITLE
Avoid undesired checkbox uncheck

### DIFF
--- a/plugins/themes/templates/theme.html
+++ b/plugins/themes/templates/theme.html
@@ -38,7 +38,7 @@
       }
     });
 
-    $(document).on("click", ".checkbox", function() {
+    $("#bl-table tbody").on("click", ".checkbox", function() {
       // allow only one checkbox checked
       $('.checkbox').not(this).prop('checked', false);
     });


### PR DESCRIPTION
This should avoid the checkbox in the backgrounds section getting unchecked everytime a checkbox is checked or unchecked in the theme options above (default, tiled, tooltip and skip empty).