### PR TITLE
fix ogc_service_url and .bak file format

### DIFF
--- a/plugins/themes/__init__.py
+++ b/plugins/themes/__init__.py
@@ -18,8 +18,8 @@ def load_plugin(app, handler):
     for setting in ["input_config_path", "qwc2_path", "qgs_resources_path", "info_templates_path"]:
         if not os.path.isdir(config.get(setting, "")):
             raise RuntimeError("%s is not set or invalid" % setting)
-    if not config.get("ogc_service_url", None):
-        raise RuntimeError("ogc_service_url is not set")
+    if not config.get("ows_prefix", None):
+        raise RuntimeError("ows_prefix is not set")
     if not config.get("default_qgis_server_url", None):
         raise RuntimeError("default_qgis_server_url is not set")
 

--- a/plugins/themes/controllers/templates_controller.py
+++ b/plugins/themes/controllers/templates_controller.py
@@ -22,8 +22,7 @@ class InfoTemplatesController():
         self.mapthumb_path = os.path.join(qwc2_path, "assets/img/mapthumbs/")
         self.featureInfoconfig = featureInfoconfig
         self.info_templates_path = current_handler.config().get("info_templates_path")
-        ogc_service_url = current_handler.config().get("ogc_service_url")
-        self.ows_prefix = current_handler.config().get("ows_prefix", urlparse(ogc_service_url).path).rstrip("/") + "/"
+        self.ows_prefix = urlparse(current_handler.config().get("ows_prefix", "")).path.rstrip("/") + "/"
         self.default_qgis_server_url = current_handler.config().get("default_qgis_server_url")
         db_engine = current_handler.db_engine()
         self.config_models = ConfigModels(db_engine, current_handler.conn_str())

--- a/plugins/themes/utils/themes.py
+++ b/plugins/themes/utils/themes.py
@@ -63,7 +63,7 @@ class ThemeUtils():
                 e.strerror))
             return False
 
-        baksuffix = ".bak%s" % datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        baksuffix = "%s.bak" % datetime.utcnow().strftime("-%Y%m%d-%H%M%S")
         themes_config = tenant_config.get("themesConfig", None)
 
         if isinstance(themes_config, str):
@@ -143,7 +143,7 @@ class ThemeUtils():
             app.logger.error("Error reading tenantConfig.json: {}".format(e.strerror))
             return False
 
-        baksuffix = ".bak%s" % datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+        baksuffix = "%s.bak" % datetime.utcnow().strftime("-%Y%m%d-%H%M%S")
         services = tenant_config.get("services", [])
 
         for service in services:

--- a/schemas/qwc-admin-gui.json
+++ b/schemas/qwc-admin-gui.json
@@ -105,10 +105,6 @@
           "description": "The path to the html info templates. Required for 'themes' plugin.",
           "type": "string"
         },
-        "ogc_service_url": {
-          "description": "The OGC service URL. Required for 'themes' plugin. Deprecated, use ows_prefix instead.",
-          "type": "string"
-        },
         "ows_prefix": {
           "description": "The OGC service URL path prefix, i.e. /ows. Required for 'themes' plugin.",
           "type": "string"


### PR DESCRIPTION
Hello, 

Regarding  https://github.com/qwc-services/qwc-admin-gui/commit/5acaf979e5078b714d5ef86dad8192d50b54b6fc, why not definitely drop ogc_service_url in favor of ows_prefix ? 

I made this PR for that. 

Also I've changed the way .bak file are generated in the theme plugin to be more coherent with the .bak files generated in the config plugin. (date before file extension).

Do not hesitate to tell me if I'm wrong. 
Kind regards, Clément. 