### PR TITLE
Read Default search provider in themeConfig.json when it is used

### DIFF
--- a/src/plugins/themes/controllers/themes_controller.py
+++ b/src/plugins/themes/controllers/themes_controller.py
@@ -401,7 +401,7 @@ class ThemesController:
             form = ThemeForm(url=theme["url"])
 
         crslist = ThemeUtils.get_crs(self.app, self.handler)
-        defaultSearchProvidersList = ThemeUtils.get_default_search_providers(self.app, self.handler)
+        defaultSearchProvidersList = self.themesconfig.get('defaultSearchProviders', [])
 
         form.url.choices = [("", "---")] + ThemeUtils.get_projects(self.app, self.handler)
         form.thumbnail.choices = ThemeUtils.get_mapthumbs(self.app, self.handler)

--- a/src/plugins/themes/utils/themes.py
+++ b/src/plugins/themes/utils/themes.py
@@ -299,29 +299,3 @@ class ThemeUtils():
         return (["EPSG:3857", "EPSG:3857"],
                 ["EPSG:4647", "EPSG:4647"],
                 ["EPSG:25832", "EPSG:25832"])
-
-    @staticmethod
-    def get_default_search_providers(app, handler):
-        """Return default search providers"""
-        current_handler = handler()
-        config_in_path = current_handler.config().get("input_config_path")
-        tenantConfig = os.path.join(config_in_path, current_handler.tenant, 'tenantConfig.json')
-
-        try:
-            with open(tenantConfig, encoding="utf-8") as fh:
-                config = json.load(fh)
-                if "themesConfig" in config:
-                    themes_config = config["themesConfig"]
-                    if "defaultSearchProviders" in themes_config:
-                        return themes_config["defaultSearchProviders"]
-                    elif type(config["themesConfig"]) is str :  # defaultSearchProviders is in themesConfig file if used
-                        themeConfig =  os.path.join(config_in_path, current_handler.tenant, config["themesConfig"])
-                        with open(themeConfig, encoding="utf-8") as fht:
-                            config_theme = json.load(fht)
-                            if "defaultSearchProviders" in config_theme:
-                                return config_theme["defaultSearchProviders"]
-        except IOError as e:
-            app.logger.error("Error reading tenantConfig.json: {}".format(
-                e.strerror))
-
-        return (["coordinates"])

--- a/src/plugins/themes/utils/themes.py
+++ b/src/plugins/themes/utils/themes.py
@@ -314,6 +314,12 @@ class ThemeUtils():
                     themes_config = config["themesConfig"]
                     if "defaultSearchProviders" in themes_config:
                         return themes_config["defaultSearchProviders"]
+                    elif type(config["themesConfig"]) is str :  # defaultSearchProviders is in themesConfig file if used
+                        themeConfig =  os.path.join(config_in_path, current_handler.tenant, config["themesConfig"])
+                        with open(themeConfig, encoding="utf-8") as fht:
+                            config_theme = json.load(fht)
+                            if "defaultSearchProviders" in config_theme:
+                                return config_theme["defaultSearchProviders"]
         except IOError as e:
             app.logger.error("Error reading tenantConfig.json: {}".format(
                 e.strerror))


### PR DESCRIPTION
Hello, 

With multi-tenancy we use themesConfig.json files. 
I notice that in theme administration interface (with Theme plugin) we didn't see the defaultSearchProviders list even if we completed it in themesConfig.json file.

In this PR if  themesConfig is a file, you go in this file to read defaultSearchProviders.

Have a nice day, 

Gwendoline Andres