### PR TITLE
Using .get() to avoid KeyError when there is no searchprovider configured

### DIFF
--- a/src/plugins/themes/controllers/themes_controller.py
+++ b/src/plugins/themes/controllers/themes_controller.py
@@ -495,7 +495,7 @@ class ThemesController:
                     form.backgroundLayers.append_entry(data)
                     form.backgroundLayers[i].layerName.choices = self.get_backgroundlayers()
                     form.backgroundLayers[i].layerName.data = layer["name"]
-            qgis_search = [provider for provider in theme["searchProviders"] if "provider" in provider and provider["provider"] == "qgis"]
+            qgis_search = [provider for provider in theme.get("searchProviders", []) if "provider" in provider and provider.get("provider") == "qgis"]
             if qgis_search :
                 for provider in qgis_search:
                     data = {


### PR DESCRIPTION
This PR aims to fix a mistake that I've made when the theme have no searchproviders configured.