### PR TITLE
Allow to set values for user info fields in dropdown list

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ To add custom user fields, add new columns to your `qwc_config.user_infos` table
   {
     "title": "<field title>",
     "name": "<column name>",
-    "type": "<field type (text|textarea|integer, default: text)>",
+    "type": "<field type (text|textarea|integer|list, default: text)>",
+    "values": "<field values in dropdown list ([(value1, label1), (value2, label2), ...]|[value1, value2, ...])>",
     "required" "<whether field is required (true|false, default: false)>"
   }
 ]

--- a/src/controllers/users_controller.py
+++ b/src/controllers/users_controller.py
@@ -140,6 +140,7 @@ class UsersController(Controller):
                     user_info = self.UserInfo()
                     # assign to user
                     user_info.user = user
+                    session.add(user_info)
 
                 # update user info fields
                 for field, value in user_info_data.items():

--- a/src/forms/user_form.py
+++ b/src/forms/user_form.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms import FormField, IntegerField, SelectMultipleField, \
+from wtforms import FormField, IntegerField, SelectField, SelectMultipleField, \
     StringField, SubmitField, TextAreaField, ValidationError, PasswordField
 from wtforms.validators import DataRequired, Optional, Email, EqualTo, \
     Length, NumberRange
@@ -84,9 +84,12 @@ class UserForm(FlaskForm):
                 field_class = StringField
             if field.get('type') == 'textarea':
                 field_class = TextAreaField
-            elif field.get('type') == 'integer':
+            if field.get('type') == 'integer':
                 field_class = IntegerField
                 widget = NumberInput()
+            elif field.get('type') == "list":
+                field_class = SelectField
+                choices = field.get('values', []) 
 
             validators = [Optional()]
             if field.get('required', False):
@@ -95,7 +98,8 @@ class UserForm(FlaskForm):
             form_field = field_class(
                 field['title'],
                 widget=widget,
-                validators=validators
+                validators=validators,
+                **({'choices': choices} if field.get('type') == "list" else {}),
             )
             # add custom field to UserInfoForm
             setattr(UserInfoForm, field['name'], form_field)

--- a/src/forms/user_form.py
+++ b/src/forms/user_form.py
@@ -80,16 +80,19 @@ class UserForm(FlaskForm):
         for field in user_info_fields:
             field_class = StringField
             widget = None
-            if field.get('type') == 'string':
-                field_class = StringField
-            if field.get('type') == 'textarea':
-                field_class = TextAreaField
-            if field.get('type') == 'integer':
-                field_class = IntegerField
-                widget = NumberInput()
-            elif field.get('type') == "list":
-                field_class = SelectField
-                choices = field.get('values', []) 
+            match field.get('type'):
+                case 'string':
+                    field_class = StringField
+                case 'textarea':
+                    field_class = TextAreaField
+                case 'integer':
+                    field_class = IntegerField
+                    widget = NumberInput()
+                case 'list':
+                    field_class = SelectField
+                    choices = field.get('values', [])
+                case _:
+                    field_class = StringField
 
             validators = [Optional()]
             if field.get('required', False):


### PR DESCRIPTION
Hi,

This PR aims to allow administrator to use list of values when using user_info_fields.

For instance, we could set `USER_INFO_FIELDS` env var to the following value in qwc-admin-gui image :

```yaml
USER_INFO_FIELDS: '[{"title": "Color", "name": "color", "type": "list", "values": [["255,0,0", "red"], ["0,255,0", "green"], ["0,0,255", "blue"], "required": true}]'
```

or

```yaml
USER_INFO_FIELDS: '[{"title": "Color", "name": "color", "type": "list", "values": ["red", "green", "blue"], "required": true}]'
```
if values and labels are the same.


Then, when creating a new user, admin can chose between all the values in dropdown list (it is an other example with some commune names):

![image](https://github.com/qwc-services/qwc-admin-gui/assets/8960009/61ab7a06-c749-4249-bd2b-c99cdca7753c)


Also, I did a first commit 01d2e7c2ecc2d5914777d4371d1488e085ad8726 because I was not able to save my new user if user_info was not added to the session (SQL Alchemy error `object of type <user_info> not in session add operation along user_infos_collection will not proceed`)

Thanks.