### PR TITLE
fix retrieval of groups from identity

### DIFF
--- a/src/access_control.py
+++ b/src/access_control.py
@@ -25,7 +25,7 @@ class AccessControl:
         # Extract user infos from identity
         if isinstance(identity, dict):
             username = identity.get('username')
-            groups = identity.get('groups')
+            groups = identity.get('groups', [])
         else:
             username = identity
             groups = []
@@ -63,7 +63,7 @@ class AccessControl:
 
         # query permissions from group roles
         group_roles_query = query.join(Role.groups_collection) \
-            .filter(Group.name.in_(groups or []))
+            .filter(Group.name.in_(groups))
 
         # combine queries
         query = groups_roles_query.union(user_roles_query) \

--- a/src/access_control.py
+++ b/src/access_control.py
@@ -42,7 +42,7 @@ class AccessControl:
         public role.
 
         :param str username: User name
-        :param str groups: Groups name
+        :param list(str) groups: List of groups name
         :param Session session: DB session
         """
         Role = self.config_models.model('roles')
@@ -63,7 +63,7 @@ class AccessControl:
 
         # query permissions from group roles
         group_roles_query = query.join(Role.groups_collection) \
-            .filter(Group.name.in_(groups))
+            .filter(Group.name.in_(groups or []))
 
         # combine queries
         query = groups_roles_query.union(user_roles_query) \

--- a/src/access_control.py
+++ b/src/access_control.py
@@ -25,24 +25,24 @@ class AccessControl:
         # Extract user infos from identity
         if isinstance(identity, dict):
             username = identity.get('username')
-            group = identity.get('group')
+            groups = identity.get('groups')
         else:
             username = identity
-            group = None
+            groups = []
         session = self.config_models.session()
-        admin_role = self.admin_role_query(username, group, session)
+        admin_role = self.admin_role_query(username, groups, session)
         session.close()
 
         return admin_role
 
-    def admin_role_query(self, username, group, session):
+    def admin_role_query(self, username, groups, session):
         """Create base query for all permissions of a user and group.
 
         Combine permissions from roles of user and user groups, group roles and
         public role.
 
         :param str username: User name
-        :param str group: Group name
+        :param str groups: Groups name
         :param Session session: DB session
         """
         Role = self.config_models.model('roles')
@@ -63,7 +63,7 @@ class AccessControl:
 
         # query permissions from group roles
         group_roles_query = query.join(Role.groups_collection) \
-            .filter(Group.name == group)
+            .filter(Group.name.in_(groups))
 
         # combine queries
         query = groups_roles_query.union(user_roles_query) \


### PR DESCRIPTION
Hi,

It seems that there is a bug on the user's groups to determine if he has the admin role.

When using  qwc-oidc-auth or qwc-ldap-auth to login, the user's groups are defined in identity["groups"] and are not unique.

This PR proposes a fix to use the groups list defined in identity to determine if a user is admin.

Let me know if there is a case were identity["group"] is used and i will modify the fix to catch both cases.

Thanks.