### PR TITLE
Fix loading of themes plugin

### DIFF
--- a/src/plugins/themes/controllers/themes_controller.py
+++ b/src/plugins/themes/controllers/themes_controller.py
@@ -121,6 +121,7 @@ class ThemesController:
         self.template_dir = "plugins/themes/templates"
 
         config_handler = handler()
+        current_handler = handler()
         db_engine = config_handler.db_engine()
         self.config_models = ConfigModels(
             db_engine, config_handler.conn_str(),


### PR DESCRIPTION
Fixes loading of themes plugin, by setting the current_handler in controller.
The error in log was:

> [2024-08-16 09:08:31,394] WARNING in server: Could not load plugin themes: name 'current_handler' is not defined