### PR TITLE
Exclude readiness and health check routes from needing authentication

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -158,7 +158,7 @@ def load_plugins():
 @app.before_request
 @optional_auth
 def assert_admin_role():
-    if request.path.startswith('/bootstrap/static/'):
+    if request.path.startswith(('/bootstrap/static/', '/ready', '/healthz')):
         return
 
     identity = get_identity()


### PR DESCRIPTION
In order to check the health and the readiness of the "qwc-admin-gui" in our cluster, the routes "/ready" and "/healthz" need to be accessed without authentication.

The proposed solution adds these routes to the same check as the bootstrap assets, to avoid the need for authentication.